### PR TITLE
Add missing error listener script

### DIFF
--- a/injected-error-listener.js
+++ b/injected-error-listener.js
@@ -1,0 +1,12 @@
+(function () {
+  window.addEventListener('error', function (e) {
+    const message = `\u274C JS Error: ${e.message} at ${e.filename}:${e.lineno}`;
+    window.postMessage({ bugsageError: message }, '*');
+  });
+
+  window.addEventListener('unhandledrejection', function (e) {
+    const reason = e.reason && e.reason.message ? e.reason.message : e.reason;
+    const message = `\u274C Unhandled Promise Rejection: ${reason}`;
+    window.postMessage({ bugsageError: message }, '*');
+  });
+})();

--- a/manifest.json
+++ b/manifest.json
@@ -30,6 +30,12 @@
       "run_at": "document_idle"
     }
   ],
+  "web_accessible_resources": [
+    {
+      "resources": ["injected-error-listener.js"],
+      "matches": ["<all_urls>"]
+    }
+  ],
   "content_security_policy": {
     "extension_pages": "script-src 'self' https://cdn.tailwindcss.com; object-src 'self'"
   }


### PR DESCRIPTION
## Summary
- add injected-error-listener.js to forward page errors
- expose script via web_accessible_resources in manifest

## Testing
- `node -c injected-error-listener.js`


------
https://chatgpt.com/codex/tasks/task_e_6865118a4bfc832e90131e63d3130a44